### PR TITLE
Improve battle victory message flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,14 +886,28 @@ function startBattle(tile) {
 }
 
 // 戦闘終了
-function endBattle(message) {
+function endBattle(message, rewardMessage = null) {
+  // 敵撃破メッセージを表示
   setLog(message);
   setTimeout(() => {
-    inBattle = false;
-    enemy = null;
-    showBattleUI(false);
-    drawMap(); // フィールド復帰
-  }, 1200);
+    if (rewardMessage) {
+      // 経験値とゴールド取得メッセージ
+      setLog(rewardMessage);
+      setTimeout(() => {
+        inBattle = false;
+        enemy = null;
+        showBattleUI(false);
+        drawMap(); // フィールド復帰
+        setLog("フィールドを探索中です。");
+      }, 800);
+    } else {
+      inBattle = false;
+      enemy = null;
+      showBattleUI(false);
+      drawMap(); // フィールド復帰
+      setLog("フィールドを探索中です。");
+    }
+  }, 800);
 }
 
 // プレイヤー・敵のターン
@@ -908,7 +922,7 @@ function playerAttack() {
     player.gold += enemy.gold;
     levelUpCheck();
     updatePlayerStatus();
-    endBattle(`${enemy.name} を たおした！`);
+    endBattle(`${enemy.name} を たおした！`, `経験値${enemy.exp}、${enemy.gold}GOLDを 手に入れた！`);
     return;
   }
   setTimeout(enemyAttack, 800);
@@ -931,7 +945,7 @@ function playerMagic() {
     player.gold += enemy.gold;
     levelUpCheck();
     updatePlayerStatus();
-    endBattle(`${enemy.name} は きえさった！`);
+    endBattle(`${enemy.name} は きえさった！`, `経験値${enemy.exp}、${enemy.gold}GOLDを 手に入れた！`);
     return;
   }
   setTimeout(enemyAttack, 800);


### PR DESCRIPTION
## Summary
- Display earned experience and gold after defeating enemies
- Clear battle text and show field exploration message when returning to the map
- Ensure victory sequence flows from enemy defeat to rewards to field exploration

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c803e89f308330962c94599f519ab0